### PR TITLE
update lifegate.it

### DIFF
--- a/easylistitaly/easylistitaly_specific_hide.txt
+++ b/easylistitaly/easylistitaly_specific_hide.txt
@@ -1569,7 +1569,6 @@ bolognafc.it##.partner-footer
 radiogardena.it##.partner-wrapper
 msmotor.tv##.partner2
 andreagaleazzi.com##.partner_box
-lifegate.it##.partnered
 dolcidee.it,luce.lanazione.it,rtinradio.com,teatronaturale.it,university-esports.it##.partners
 100ideeperristrutturare.it,casa-naturale.com,quattrozampe.online,villeecasali.com##.partners-wrapper
 infobuild.it##.partnersection


### PR DESCRIPTION
Con questa regola venivano bloccati i redazionali linkati sulla homepage del sito, che non sono banner pubblicitari, ma articoli che hanno uno sponsor ma che  trattano argomenti di utilità generale (sono molto presenti nella home lifegate)
Sono articoli come  questo
https://www.lifegate.it/lino-barometro-2021
o questo
https://www.lifegate.it/dolomeyes-acqua-montagna-dolomiti
che non mi sembra rientrino nel contesto ads e non mi aspetto vengano bloccati da adblock