### PR TITLE
remove obsolete rule

### DIFF
--- a/easylistitaly/easylistitaly_specific_hide.txt
+++ b/easylistitaly/easylistitaly_specific_hide.txt
@@ -19,7 +19,6 @@ acsi.it###Parteners
 scambieuropei.info###T
 flashgames.it###T_1
 leggopassword.it###Tabella_01
-chimerarevo.com###TopWidgetArea
 caffebaiadomizia.it###_ad_10926
 panoz.it###ad
 bsshotel.it,soldioggi.it###ad1


### PR DESCRIPTION
The domain changed owner, its rules are now obsolete and can be removed.